### PR TITLE
Return 0 for bashrc

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -198,7 +198,7 @@ in
         ${cfg.bashrcExtra}
 
         # Commands that should be applied only for interactive shells.
-        [[ $- == *i* ]] || return
+        [[ $- == *i* ]] || return 0
 
         ${historyControlStr}
 


### PR DESCRIPTION
The call to `return` without a value causes it to return the value of the last command, which in this case is the false comparison. Therefore, anyone sourcing this file in a non-interactive environment will get a return value of `1` after the call. Adding an explicit `return 0` instead will cause this file to return successfully and not produce extraneous errors in sourcing scripts.